### PR TITLE
Show PST files with color-coded size

### DIFF
--- a/OutlookRefresh/MainWindow.xaml
+++ b/OutlookRefresh/MainWindow.xaml
@@ -14,6 +14,19 @@
     </Window.SystemBackdrop>
 
     <Grid>
-
+        <ListView ItemsSource="{x:Bind PstFiles}">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="local:PstFileInfo">
+                    <Grid Background="{x:Bind Background}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="{x:Bind Path}" Margin="4" />
+                        <TextBlock Text="{x:Bind SizeGb, Mode=OneWay, StringFormat=\"{0:F1} GB\"}" Grid.Column="1" Margin="4" />
+                    </Grid>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
     </Grid>
 </Window>

--- a/OutlookRefresh/MainWindow.xaml.cs
+++ b/OutlookRefresh/MainWindow.xaml.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -23,9 +21,34 @@ namespace OutlookRefresh
     /// </summary>
     public sealed partial class MainWindow : Window
     {
+        public ObservableCollection<PstFileInfo> PstFiles { get; } = new();
+
         public MainWindow()
         {
             InitializeComponent();
+            LoadPstFiles();
+        }
+
+        private void LoadPstFiles()
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            try
+            {
+                var files = Directory.GetFiles(home, "*.pst", SearchOption.AllDirectories);
+                foreach (var file in files)
+                {
+                    double sizeGb = new FileInfo(file).Length / (1024.0 * 1024 * 1024);
+                    var color = sizeGb < 35 ? Windows.UI.Color.FromArgb(128, 0, 255, 0) :
+                                 sizeGb < 45 ? Windows.UI.Color.FromArgb(128, 255, 165, 0) :
+                                 Windows.UI.Color.FromArgb(128, 255, 0, 0);
+                    var brush = new SolidColorBrush(color);
+                    PstFiles.Add(new PstFileInfo { Path = file, SizeGb = sizeGb, Background = brush });
+                }
+            }
+            catch
+            {
+                // ignore errors scanning directories
+            }
         }
     }
 }

--- a/OutlookRefresh/PstFileInfo.cs
+++ b/OutlookRefresh/PstFileInfo.cs
@@ -1,0 +1,9 @@
+namespace OutlookRefresh
+{
+    public class PstFileInfo
+    {
+        public string Path { get; set; } = string.Empty;
+        public double SizeGb { get; set; }
+        public Microsoft.UI.Xaml.Media.Brush? Background { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- display PST files found in the user's profile directory
- highlight list items based on size

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cec186f688320bc5f99836e74a528