### PR TITLE
Improve PST search robustness

### DIFF
--- a/OutlookRefresh/MainWindow.xaml.cs
+++ b/OutlookRefresh/MainWindow.xaml.cs
@@ -35,23 +35,20 @@ namespace OutlookRefresh
 
             try
             {
-                var outlookDirs = Directory.GetDirectories(documents, "*Outlook*", SearchOption.AllDirectories);
+                var files = Directory.EnumerateFiles(
+                    documents,
+                    "*.pst",
+                    new EnumerationOptions { IgnoreInaccessible = true, RecurseSubdirectories = true });
 
-                foreach (var dir in outlookDirs)
+                foreach (var file in files)
                 {
-                    var files = Directory.GetFiles(dir, "*.pst", SearchOption.TopDirectoryOnly);
+                    double sizeGb = new FileInfo(file).Length / (1024.0 * 1024 * 1024);
+                    var color = sizeGb < 35 ? Microsoft.UI.Colors.LightGreen :
+                                 sizeGb < 45 ? Microsoft.UI.Colors.Orange :
+                                 Microsoft.UI.Colors.Red;
+                    var brush = new SolidColorBrush(color);
 
-                    foreach (var file in files)
-                    {
-                        double sizeGb = new FileInfo(file).Length / (1024.0 * 1024 * 1024);
-                        var color = sizeGb < 35 ? Microsoft.UI.Colors.LightGreen :
-                                     sizeGb < 45 ? Microsoft.UI.Colors.Orange :
-                                     Microsoft.UI.Colors.Red;
-                        var brush = new SolidColorBrush(color);
-
-
-                        PstFiles.Add(new PstFileInfo { Path = file, SizeGb = sizeGb, Background = brush });
-                    }
+                    PstFiles.Add(new PstFileInfo { Path = file, SizeGb = sizeGb, Background = brush });
                 }
             }
             catch


### PR DESCRIPTION
## Summary
- handle inaccessible directories when searching for PST files

## Testing
- `dotnet build OutlookRefresh.sln -c Release` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_6876000882a883209018a7f6a24aa52f